### PR TITLE
fix: fix swallowing ticks on TickerFunc

### DIFF
--- a/mock_test.go
+++ b/mock_test.go
@@ -292,9 +292,13 @@ func TestTickerFunc_LongCallback(t *testing.T) {
 	case <-testCtx.Done():
 		t.Fatal("timeout waiting for tickStart")
 	}
-	// second tick completes immediately, since it doesn't actually call the
-	// ticker function.
-	mClock.Advance(time.Second).MustWait(testCtx)
+	// additional ticks complete immediately.
+	elapsed := time.Duration(0)
+	for elapsed < 5*time.Second {
+		d, wt := mClock.AdvanceNext()
+		elapsed += d
+		wt.MustWait(testCtx)
+	}
 
 	waitErr := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
Turns out #7 is bugged.  When we refused to call the TickerFunc callback, we didn't advance the next event time, so the Mock kept re-scheduling `fire()` and we could never finish processing on the tick time.