### PR TITLE
fix a bug where AdvanceNext unlock twice

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -349,6 +349,7 @@ func (m *Mock) AdvanceNext() (time.Duration, AdvanceWaiter) {
 		defer close(w.ch)
 		defer m.mu.Unlock()
 		m.tb.Error("cannot AdvanceNext because there are no timers or tickers running")
+		return 0, w
 	}
 	d := m.nextTime.Sub(m.cur)
 	m.cur = m.nextTime


### PR DESCRIPTION
How to reproduce:

```
func TestQuartz_AdvanceNext(t *testing.T) {
    clock := quartz.NewMock(t)
    clock.AdvanceNext()
    time.Sleep(time.Second)
}
```

Output:

```
fatal error: sync: unlock of unlocked mutex

goroutine 19 [running]:
sync.fatal({0x86845ba?, 0x86dd020?})
    runtime/panic.go:1031 +0x18
sync.(*Mutex).unlockSlow(0xc0000f2010, 0xffffffff)
    sync/mutex.go:231 +0x35
sync.(*Mutex).Unlock(...)
    sync/mutex.go:225
github.com/coder/quartz.(*Mock).advanceLocked(0xc0000f2000, {{0x86f6058?, 0xc0000a6820?}, 0xc00008e310?})
    github.com/coder/quartz/mock.go:299 +0x1a7
created by github.com/coder/quartz.(*Mock).AdvanceNext in goroutine 18
    github.com/coder/quartz/mock.go:355 +0x28b

goroutine 1 [chan receive]:
testing.(*T).Run(0xc0000a6680, {0x8681fa8?, 0xfb73180009ab50?}, 0x86f2f68)
    testing/testing.go:1751 +0x3ab
testing.runTests.func1(0xc0000a6680)
    testing/testing.go:2168 +0x37
testing.tRunner(0xc0000a6680, 0xc00009ac70)
    testing/testing.go:1690 +0xf4
testing.runTests(0xc00009e180, {0x87d5d60, 0x9, 0x9}, {0x85bd7d0?, 0x85bd43a?, 0x87da620?})
    testing/testing.go:2166 +0x43d
testing.(*M).Run(0xc0000ac0a0)
    testing/testing.go:2034 +0x64a
main.main()
    _testmain.go:63 +0x9b

goroutine 18 [sleep]:
time.Sleep(0x3b9aca00)
    runtime/time.go:300 +0xf2
github.com/coder/quartz_test.TestQuartz_AdvanceNext(0xc0000a6820?)
    github.com/coder/quartz/mock_test.go:326 +0x2f
testing.tRunner(0xc0000a6820, 0x86f2f68)
    testing/testing.go:1690 +0xf4
created by testing.(*T).Run in goroutine 1
    testing/testing.go:1743 +0x390
exit status 2
```

Cause:

```
https://github.com/coder/quartz/blob/7f10f7fd6925130f6548710df54992e832cfce2d/mock.go#L348
```
