### PR TITLE
fix: clear stale schedule on Timer.Reset with non-positive duration

### DIFF
--- a/mock_test.go
+++ b/mock_test.go
@@ -550,6 +550,47 @@ func TestTimerReset_Go123(t *testing.T) {
 	}
 }
 
+// TestTimerReset_NegativeDuration verifies that resetting a still-active timer
+// to a non-positive duration clears its old schedule from the mock
+// synchronously. Otherwise, subsequent Advance/Peek calls race with the
+// fire goroutine and may observe the stale schedule (e.g. Advance beyond the
+// old nxt is incorrectly rejected).
+func TestTimerReset_NegativeDuration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	mClock := quartz.NewMock(t)
+	trapReset := mClock.Trap().TimerReset()
+	defer trapReset.Close()
+
+	tmr := mClock.NewTimer(time.Hour)
+
+	results := make(chan bool, 1)
+	go func() {
+		results <- tmr.Reset(-time.Second)
+	}()
+	trapReset.MustWait(ctx).MustRelease(ctx)
+	if !<-results {
+		t.Fatal("Reset should report the timer was active")
+	}
+
+	// The timer's old 1h schedule must not remain in the mock's event list.
+	// If it does, Advance rejects with "cannot advance beyond next
+	// timer/ticker event".
+	if d, ok := mClock.Peek(); ok {
+		t.Fatalf("expected no pending events, got Peek()=%s", d)
+	}
+	mClock.Advance(2 * time.Hour).MustWait(ctx)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for timer")
+	case <-tmr.C:
+		// OK
+	}
+}
+
 func TestNoLeak_Go123(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/timer.go
+++ b/timer.go
@@ -103,14 +103,17 @@ func (t *Timer) Reset(d time.Duration, tags ...string) bool {
 		<-t.interrupt
 		t.interrupt = nil
 	}
+	// Remove the timer from the mock's event list synchronously; otherwise the
+	// stale old schedule can cause e.g. Advance() to reject advancing past the
+	// old nxt, even though the timer has been reset.
+	t.mock.removeTimerLocked(t)
 	if d <= 0 {
 		// zero or negative duration timer means we should immediately re-fire
-		// it, rather than remove and re-add it.
+		// it, rather than re-add it.
 		t.stopped = false
 		go t.fire(t.mock.cur)
 		return result
 	}
-	t.mock.removeTimerLocked(t)
 	t.stopped = false
 	t.nxt = t.mock.cur.Add(d)
 	t.mock.addEventLocked(t)


### PR DESCRIPTION
## Summary

- `Timer.Reset(d)` with `d <= 0` on a still-active timer left the old schedule in the mock's event list until the async `go fire()` goroutine happened to run
- In the race window, `Peek()` returned the stale old duration and `Advance()` beyond the old `nxt` was incorrectly rejected with `cannot advance beyond next timer/ticker event`
- Fix: hoist `removeTimerLocked(t)` above the `d <= 0` branch so it runs synchronously in both paths; `fire`'s own call is idempotent

## Repro

Before the fix, the new test fails near-deterministically with `expected no pending events, got Peek()=1h0m0s`. After the fix, it passes.

## Test plan

- [x] `go test -race -count=1 ./...` (full suite) passes
- [x] `go test -race -count=50 -run TestTimerReset_NegativeDuration ./...` fails without the fix, passes with it
- [x] No API change; no behavior change in the common `d > 0` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)