### PR TITLE
feat!: add Clock-backed context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,30 @@ gotBaz := <-baz // ?? never trapped, so races with Advance()
 Tags appear as an optional suffix on all `Clock` methods (type `...string`) and are ignored entirely
 by the real clock. They also appear on all methods on returned timers and tickers.
 
+### Contexts
+
+`Clock` provides `WithDeadline`, `WithDeadlineCause`, `WithTimeout`, and `WithTimeoutCause` methods
+that mirror the standard `context` package. With a `*Mock`, deadlines created through the clock
+advance on mock time:
+
+```go
+ctx, cancel := mClock.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+mClock.Advance(30 * time.Second).MustWait(testCtx)
+if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+	t.Fatal("expected deadline exceeded")
+}
+```
+
+Deadlines created through `mClock.WithDeadline` and `mClock.WithTimeout` use mock time. Parent
+contexts keep standard `context` behavior. A parent created with `context.WithDeadline` or
+`context.WithTimeout` can still cancel the child on wall time because Quartz does not convert
+parent deadlines to mock time.
+
+Call the returned cancel function as you would for `context.WithTimeout`. It is idempotent and
+removes the pending mock event. Cause variants preserve the cause for `context.Cause`.
+
 ## Recommended Patterns
 
 ### Options

--- a/clock.go
+++ b/clock.go
@@ -35,6 +35,26 @@ type Clock interface {
 	Since(t time.Time, tags ...string) time.Duration
 	// Until returns the duration until t. It is shorthand for t.Sub(Clock.Now()).
 	Until(t time.Time, tags ...string) time.Duration
+
+	// WithDeadline returns a copy of parent with a deadline governed by this Clock. When the
+	// deadline is reached, Err satisfies errors.Is(err, context.DeadlineExceeded). Parent
+	// cancellation propagates with stdlib semantics. Parent deadlines are not converted to mock
+	// time, so a parent created with context.WithDeadline or context.WithTimeout can cancel the
+	// child independently of this Clock. The returned cancel function is idempotent and must be
+	// called.
+	WithDeadline(parent context.Context, d time.Time, tags ...string) (context.Context, context.CancelFunc)
+
+	// WithDeadlineCause returns a copy of parent with a deadline governed by this Clock and
+	// records cause when this Clock reaches the deadline.
+	WithDeadlineCause(parent context.Context, d time.Time, cause error, tags ...string) (context.Context, context.CancelFunc)
+
+	// WithTimeout returns a copy of parent with a timeout governed by this Clock. It is shorthand
+	// for WithDeadline(parent, Clock.Now().Add(d)).
+	WithTimeout(parent context.Context, d time.Duration, tags ...string) (context.Context, context.CancelFunc)
+
+	// WithTimeoutCause returns a copy of parent with a timeout governed by this Clock and records
+	// cause when this Clock reaches the timeout.
+	WithTimeoutCause(parent context.Context, d time.Duration, cause error, tags ...string) (context.Context, context.CancelFunc)
 }
 
 // Waiter can be waited on for an error.

--- a/mock.go
+++ b/mock.go
@@ -23,6 +23,10 @@ type TestingT interface {
 	Cleanup(func())
 }
 
+// ErrMockClockTestEnded is used as the cancellation cause when test cleanup
+// cancels a context that was not canceled by its caller.
+var ErrMockClockTestEnded = errors.New("quartz: mock clock test ended")
+
 // Mock is the testing implementation of Clock.  It tracks a time that monotonically increases
 // during a test, triggering any timers or tickers automatically.
 type Mock struct {
@@ -154,6 +158,71 @@ func (m *Mock) Until(t time.Time, tags ...string) time.Duration {
 	return t.Sub(m.cur)
 }
 
+func (m *Mock) WithDeadline(parent context.Context, d time.Time, tags ...string) (context.Context, context.CancelFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c := newCall(clockFunctionWithDeadline, tags, withTime(d))
+	m.matchCallLocked(c)
+	defer close(c.complete)
+	return m.withDeadlineCauseLocked(parent, d, nil)
+}
+
+func (m *Mock) WithDeadlineCause(parent context.Context, d time.Time, cause error, tags ...string) (context.Context, context.CancelFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c := newCall(clockFunctionWithDeadlineCause, tags, withTime(d), withCause(cause))
+	m.matchCallLocked(c)
+	defer close(c.complete)
+	return m.withDeadlineCauseLocked(parent, d, cause)
+}
+
+func (m *Mock) WithTimeout(parent context.Context, d time.Duration, tags ...string) (context.Context, context.CancelFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c := newCall(clockFunctionWithTimeout, tags, withDuration(d))
+	m.matchCallLocked(c)
+	defer close(c.complete)
+	deadline := m.cur.Add(d)
+	return m.withDeadlineCauseLocked(parent, deadline, nil)
+}
+
+func (m *Mock) WithTimeoutCause(parent context.Context, d time.Duration, cause error, tags ...string) (context.Context, context.CancelFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c := newCall(clockFunctionWithTimeoutCause, tags, withDuration(d), withCause(cause))
+	m.matchCallLocked(c)
+	defer close(c.complete)
+	deadline := m.cur.Add(d)
+	return m.withDeadlineCauseLocked(parent, deadline, cause)
+}
+
+func (m *Mock) withDeadlineCauseLocked(parent context.Context, d time.Time, cause error) (context.Context, context.CancelFunc) {
+	inner, innerCancel := context.WithCancelCause(parent)
+	c := &mockCtx{
+		inner:       inner,
+		innerCancel: innerCancel,
+		deadline:    d,
+		cause:       cause,
+		mock:        m,
+		done:        make(chan struct{}),
+	}
+	if !d.After(m.cur) {
+		// Mirror NewTimer and AfterFunc behavior for past deadlines.
+		go c.fire(m.cur)
+	} else {
+		m.addEventLocked(c)
+	}
+	context.AfterFunc(inner, func() {
+		c.cancelFromInner(inner.Err())
+	})
+	m.tb.Cleanup(func() {
+		c.cancel(context.Canceled, ErrMockClockTestEnded)
+	})
+	return c, func() {
+		c.cancel(context.Canceled, nil)
+	}
+}
+
 func (m *Mock) addEventLocked(e event) {
 	m.all = append(m.all, e)
 	m.recomputeNextLocked()
@@ -186,6 +255,12 @@ func (m *Mock) removeTimer(t *Timer) {
 func (m *Mock) removeTimerLocked(t *Timer) {
 	t.stopped = true
 	m.removeEventLocked(t)
+}
+
+func (m *Mock) removeEvent(e event) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.removeEventLocked(e)
 }
 
 func (m *Mock) removeEventLocked(e event) {
@@ -444,6 +519,22 @@ func (t Trapper) Until(tags ...string) *Trap {
 	return t.mock.newTrap(clockFunctionUntil, tags)
 }
 
+func (t Trapper) WithDeadline(tags ...string) *Trap {
+	return t.mock.newTrap(clockFunctionWithDeadline, tags)
+}
+
+func (t Trapper) WithDeadlineCause(tags ...string) *Trap {
+	return t.mock.newTrap(clockFunctionWithDeadlineCause, tags)
+}
+
+func (t Trapper) WithTimeout(tags ...string) *Trap {
+	return t.mock.newTrap(clockFunctionWithTimeout, tags)
+}
+
+func (t Trapper) WithTimeoutCause(tags ...string) *Trap {
+	return t.mock.newTrap(clockFunctionWithTimeoutCause, tags)
+}
+
 func (m *Mock) Trap() Trapper {
 	return Trapper{m}
 }
@@ -583,6 +674,99 @@ func (m *mockTickerFunc) Wait(tags ...string) error {
 
 var _ Waiter = &mockTickerFunc{}
 
+type mockCtx struct {
+	// inner stores cancellation causes. Value delegates to it so context.Cause
+	// can find the stdlib cancelCtx. Done must return c.done, not inner.Done,
+	// or stdlib descendants attach to inner and inherit its context.Canceled
+	// Err when a mock deadline fires.
+	inner       context.Context
+	innerCancel context.CancelCauseFunc
+	deadline    time.Time
+	cause       error
+
+	mock *Mock
+
+	mu         sync.Mutex // Protects the following fields.
+	err        error
+	done       chan struct{}
+	doneClosed bool
+}
+
+func (c *mockCtx) Deadline() (time.Time, bool) {
+	return c.deadline, true
+}
+
+func (c *mockCtx) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *mockCtx) Value(key any) any {
+	return c.inner.Value(key)
+}
+
+func (c *mockCtx) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.doneClosed {
+		return nil
+	}
+	return c.err
+}
+
+func (c *mockCtx) next() time.Time {
+	return c.deadline
+}
+
+func (c *mockCtx) fire(_ time.Time) {
+	c.cancel(context.DeadlineExceeded, c.cause)
+}
+
+func (c *mockCtx) cancel(err, cause error) {
+	if innerErr := c.inner.Err(); innerErr != nil {
+		c.cancelFromInner(innerErr)
+		return
+	}
+	if cause == nil {
+		cause = err
+	}
+	c.cancelOnce(err, cause, true)
+}
+
+func (c *mockCtx) cancelFromInner(err error) {
+	if err == nil {
+		err = context.Canceled
+	}
+	c.cancelOnce(err, nil, false)
+}
+
+func (c *mockCtx) cancelOnce(err, cause error, cancelInner bool) {
+	c.mu.Lock()
+	if c.err != nil {
+		done := c.done
+		doneClosed := c.doneClosed
+		c.mu.Unlock()
+		if !doneClosed {
+			<-done
+		}
+		return
+	}
+	c.err = err
+	c.mu.Unlock()
+
+	// Remove the scheduled deadline before closing Done, so callers
+	// waiting on Done can observe cancellation without seeing a stale
+	// event in Peek or AdvanceNext.
+	c.mock.removeEvent(c)
+
+	c.mu.Lock()
+	if cancelInner {
+		c.innerCancel(cause)
+	}
+	c.doneClosed = true
+	close(c.done)
+	c.mu.Unlock()
+}
+
 type clockFunction int
 
 const (
@@ -598,6 +782,10 @@ const (
 	clockFunctionNow
 	clockFunctionSince
 	clockFunctionUntil
+	clockFunctionWithDeadline
+	clockFunctionWithDeadlineCause
+	clockFunctionWithTimeout
+	clockFunctionWithTimeoutCause
 )
 
 func (c clockFunction) String() string {
@@ -626,6 +814,14 @@ func (c clockFunction) String() string {
 		return "Since"
 	case clockFunctionUntil:
 		return "Until"
+	case clockFunctionWithDeadline:
+		return "WithDeadline"
+	case clockFunctionWithDeadlineCause:
+		return "WithDeadlineCause"
+	case clockFunctionWithTimeout:
+		return "WithTimeout"
+	case clockFunctionWithTimeoutCause:
+		return "WithTimeoutCause"
 	default:
 		return fmt.Sprintf("Unknown clockFunction(%d)", c)
 	}
@@ -637,6 +833,7 @@ type callArg func(c *apiCall)
 type apiCall struct {
 	Time     time.Time
 	Duration time.Duration
+	Cause    error
 	Tags     []string
 
 	fn       clockFunction
@@ -670,6 +867,14 @@ func (a *apiCall) String() string {
 		return fmt.Sprintf("Since(%s, %v)", a.Time, a.Tags)
 	case clockFunctionUntil:
 		return fmt.Sprintf("Until(%s, %v)", a.Time, a.Tags)
+	case clockFunctionWithDeadline:
+		return fmt.Sprintf("WithDeadline(<ctx>, %s, %v)", a.Time, a.Tags)
+	case clockFunctionWithDeadlineCause:
+		return fmt.Sprintf("WithDeadlineCause(<ctx>, %s, cause=%v, %v)", a.Time, a.Cause, a.Tags)
+	case clockFunctionWithTimeout:
+		return fmt.Sprintf("WithTimeout(<ctx>, %s, %v)", a.Duration, a.Tags)
+	case clockFunctionWithTimeoutCause:
+		return fmt.Sprintf("WithTimeoutCause(<ctx>, %s, cause=%v, %v)", a.Duration, a.Cause, a.Tags)
 	default:
 		return fmt.Sprintf("Unknown clockFunction(%d)", a.fn)
 	}
@@ -679,6 +884,7 @@ func (a *apiCall) String() string {
 type Call struct {
 	Time     time.Time
 	Duration time.Duration
+	Cause    error // Cause passed to a cause variant, if applicable.
 	Tags     []string
 
 	tb      TestingT
@@ -724,6 +930,12 @@ func withTime(t time.Time) callArg {
 func withDuration(d time.Duration) callArg {
 	return func(c *apiCall) {
 		c.Duration = d
+	}
+}
+
+func withCause(err error) callArg {
+	return func(c *apiCall) {
+		c.Cause = err
 	}
 }
 
@@ -814,6 +1026,7 @@ func (t *Trap) Wait(ctx context.Context) (*Call, error) {
 		c := &Call{
 			Time:     a.Time,
 			Duration: a.Duration,
+			Cause:    a.Cause,
 			Tags:     a.Tags,
 			apiCall:  a,
 			trap:     t,

--- a/mock_test.go
+++ b/mock_test.go
@@ -325,6 +325,304 @@ func TestTickerFunc_LongCallback(t *testing.T) {
 	w.MustWait(testCtx)
 }
 
+func TestWithTimeout_FiresOnAdvance(t *testing.T) {
+	t.Parallel()
+	testCtx, testCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer testCancel()
+
+	mClock := quartz.NewMock(t)
+	ctx, cancel := mClock.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	child, childCancel := context.WithCancel(ctx)
+	defer childCancel()
+
+	mClock.Advance(time.Second).MustWait(testCtx)
+
+	select {
+	case <-ctx.Done():
+		// OK
+	case <-testCtx.Done():
+		t.Fatal("timeout waiting for context deadline")
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", ctx.Err())
+	}
+	select {
+	case <-child.Done():
+		// OK
+	case <-testCtx.Done():
+		t.Fatal("timeout waiting for child context")
+	}
+	if !errors.Is(child.Err(), context.DeadlineExceeded) {
+		t.Fatalf("expected child DeadlineExceeded, got %v", child.Err())
+	}
+}
+
+func TestWithDeadline_Deadline(t *testing.T) {
+	t.Parallel()
+
+	mClock := quartz.NewMock(t)
+	deadline := mClock.Now().Add(time.Hour)
+	ctx, cancel := mClock.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	got, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected deadline")
+	}
+	if !got.Equal(deadline) {
+		t.Fatalf("expected deadline %s, got %s", deadline, got)
+	}
+}
+
+func TestWithTimeout_CancelIsIdempotentAndRemovesEvent(t *testing.T) {
+	t.Parallel()
+	testCtx, testCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer testCancel()
+
+	mClock := quartz.NewMock(t)
+	ctx, cancel := mClock.WithTimeout(context.Background(), time.Hour)
+
+	cancel()
+	cancel()
+	select {
+	case <-ctx.Done():
+		// OK
+	case <-testCtx.Done():
+		t.Fatal("timeout waiting for canceled context")
+	}
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("expected Canceled, got %v", ctx.Err())
+	}
+	if d, ok := mClock.Peek(); ok {
+		t.Fatalf("expected no pending events, got Peek()=%s", d)
+	}
+	mClock.Advance(2 * time.Hour).MustWait(testCtx)
+}
+
+func TestWithTimeout_ParentCanceled(t *testing.T) {
+	t.Parallel()
+	testCtx, testCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer testCancel()
+
+	mClock := quartz.NewMock(t)
+	parent, parentCancel := context.WithCancel(context.Background())
+	ctx, cancel := mClock.WithTimeout(parent, time.Hour)
+	defer cancel()
+
+	parentCancel()
+	select {
+	case <-ctx.Done():
+		// OK
+	case <-testCtx.Done():
+		t.Fatal("timeout waiting for parent cancellation")
+	}
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("expected Canceled, got %v", ctx.Err())
+	}
+	if d, ok := mClock.Peek(); ok {
+		t.Fatalf("expected no pending events, got Peek()=%s", d)
+	}
+}
+
+func TestWithTimeout_ParentDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+	testCtx, testCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer testCancel()
+
+	mClock := quartz.NewMock(t)
+	parent, parentCancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer parentCancel()
+	ctx, cancel := mClock.WithTimeout(parent, time.Hour)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		// A wall-clock parent deadline must still cancel mock-clock children.
+		// This keeps test timeout guards effective when mock time is stalled.
+	case <-testCtx.Done():
+		t.Fatal("timeout waiting for parent deadline")
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", ctx.Err())
+	}
+	if d, ok := mClock.Peek(); ok {
+		t.Fatalf("expected no pending events, got Peek()=%s", d)
+	}
+}
+
+func TestWithTimeoutCause_Cause(t *testing.T) {
+	t.Parallel()
+	testCtx, testCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer testCancel()
+
+	mClock := quartz.NewMock(t)
+	expectedErr := errors.New("deadline cause")
+	ctx, cancel := mClock.WithTimeoutCause(context.Background(), time.Second, expectedErr)
+	defer cancel()
+	child, childCancel := context.WithCancel(ctx)
+	defer childCancel()
+
+	mClock.Advance(time.Second).MustWait(testCtx)
+
+	select {
+	case <-child.Done():
+		// OK
+	case <-testCtx.Done():
+		t.Fatal("timeout waiting for child context")
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", ctx.Err())
+	}
+	if !errors.Is(context.Cause(ctx), expectedErr) {
+		t.Fatalf("expected cause %v, got %v", expectedErr, context.Cause(ctx))
+	}
+	if !errors.Is(context.Cause(child), expectedErr) {
+		t.Fatalf("expected child cause %v, got %v", expectedErr, context.Cause(child))
+	}
+}
+
+func TestWithTimeout_PastDeadline(t *testing.T) {
+	t.Parallel()
+	testCtx, testCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer testCancel()
+
+	for _, d := range []time.Duration{0, -time.Second} {
+		t.Run(d.String(), func(t *testing.T) {
+			mClock := quartz.NewMock(t)
+			ctx, cancel := mClock.WithTimeout(context.Background(), d)
+			defer cancel()
+
+			select {
+			case <-ctx.Done():
+				// OK
+			case <-testCtx.Done():
+				t.Fatal("timeout waiting for past deadline")
+			}
+			if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				t.Fatalf("expected DeadlineExceeded, got %v", ctx.Err())
+			}
+			if d, ok := mClock.Peek(); ok {
+				t.Fatalf("expected no pending events, got Peek()=%s", d)
+			}
+		})
+	}
+}
+
+func TestWithTimeout_CancelRace(t *testing.T) {
+	t.Parallel()
+	testCtx, testCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer testCancel()
+
+	mClock := quartz.NewMock(t)
+	parent, parentCancel := context.WithCancel(context.Background())
+	defer parentCancel()
+	ctx, cancel := mClock.WithTimeout(parent, time.Second)
+	defer cancel()
+	child, childCancel := context.WithCancel(ctx)
+	defer childCancel()
+	start := make(chan struct{})
+	done := make(chan struct{}, 4)
+
+	go func() {
+		<-start
+		mClock.Advance(time.Second).MustWait(testCtx)
+		done <- struct{}{}
+	}()
+	go func() {
+		<-start
+		cancel()
+		done <- struct{}{}
+	}()
+	go func() {
+		<-start
+		parentCancel()
+		done <- struct{}{}
+	}()
+	go func() {
+		<-start
+		for {
+			select {
+			case <-ctx.Done():
+				_ = ctx.Err()
+				_ = child.Err()
+				done <- struct{}{}
+				return
+			default:
+				_ = ctx.Err()
+				_ = child.Err()
+			}
+		}
+	}()
+
+	close(start)
+	for range 4 {
+		select {
+		case <-done:
+		case <-testCtx.Done():
+			t.Fatal("timeout waiting for cancel race")
+		}
+	}
+}
+
+func TestWithTimeout_Trap(t *testing.T) {
+	t.Parallel()
+	testCtx, testCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer testCancel()
+
+	mClock := quartz.NewMock(t)
+	trap := mClock.Trap().WithTimeout("ctx")
+	defer trap.Close()
+	ctxs := make(chan context.Context, 1)
+	cancels := make(chan context.CancelFunc, 1)
+	go func() {
+		ctx, cancel := mClock.WithTimeout(context.Background(), time.Hour, "ctx")
+		ctxs <- ctx
+		cancels <- cancel
+	}()
+
+	call := trap.MustWait(testCtx)
+	if call.Duration != time.Hour {
+		t.Fatalf("expected time.Hour, got %v", call.Duration)
+	}
+	call.MustRelease(testCtx)
+	ctx := <-ctxs
+	cancel := <-cancels
+	defer cancel()
+	mClock.Advance(time.Hour).MustWait(testCtx)
+	select {
+	case <-ctx.Done():
+		// OK
+	case <-testCtx.Done():
+		t.Fatal("timeout waiting for trapped context")
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", ctx.Err())
+	}
+
+	causeErr := errors.New("trap cause")
+	trapCause := mClock.Trap().WithTimeoutCause("cause")
+	defer trapCause.Close()
+	go func() {
+		ctx, cancel := mClock.WithTimeoutCause(context.Background(), time.Minute, causeErr, "cause")
+		ctxs <- ctx
+		cancels <- cancel
+	}()
+
+	call = trapCause.MustWait(testCtx)
+	if call.Duration != time.Minute {
+		t.Fatalf("expected time.Minute, got %v", call.Duration)
+	}
+	if !errors.Is(call.Cause, causeErr) {
+		t.Fatalf("expected cause %v, got %v", causeErr, call.Cause)
+	}
+	call.MustRelease(testCtx)
+	ctx = <-ctxs
+	cancel = <-cancels
+	cancel()
+	<-ctx.Done()
+}
+
 func Test_MultipleTraps(t *testing.T) {
 	t.Parallel()
 	testCtx, testCancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/real.go
+++ b/real.go
@@ -77,4 +77,20 @@ func (realClock) Until(t time.Time, _ ...string) time.Duration {
 	return time.Until(t)
 }
 
+func (realClock) WithDeadline(parent context.Context, d time.Time, _ ...string) (context.Context, context.CancelFunc) {
+	return context.WithDeadline(parent, d)
+}
+
+func (realClock) WithDeadlineCause(parent context.Context, d time.Time, cause error, _ ...string) (context.Context, context.CancelFunc) {
+	return context.WithDeadlineCause(parent, d, cause)
+}
+
+func (realClock) WithTimeout(parent context.Context, d time.Duration, _ ...string) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, d)
+}
+
+func (realClock) WithTimeoutCause(parent context.Context, d time.Duration, cause error, _ ...string) (context.Context, context.CancelFunc) {
+	return context.WithTimeoutCause(parent, d, cause)
+}
+
 var _ Clock = realClock{}


### PR DESCRIPTION
This change lets users create context timeouts that are scheduled on
mock time by introducing four new methods on Clock. The parent context
cancellation is respected, and its timeout may still run on wall time,
which allows use cases like setting maximum runtime limits for tests
and keeps the model simple as Quartz does not translate wall time to
mock time.

Closes #14
Part of ENG-2715

BREAKING CHANGE: Clock gained four new methods, which is technically a
breakage of the public API. Impact should be minimal considering Clock
is not meant to be faked outside of this package.
